### PR TITLE
[CORRIGIDO] Erro do link no email de recuperação

### DIFF
--- a/app/auth/email.py
+++ b/app/auth/email.py
@@ -13,6 +13,6 @@ def send_password_reset_email(user):
             'email/reset_password.txt', user=user, token=token
         ),
         html_body=render_template(
-            'email/reset_password.html', user=user, tokne=token
+            'email/reset_password.html', user=user, token=token
         )
     )


### PR DESCRIPTION
Infelizmente uma letra fora do lugar estava causando o bug do link incompleto no email.